### PR TITLE
x11-misc/emprint: remove obsolete DEPEND value

### DIFF
--- a/x11-misc/emprint/emprint-9999.ebuild
+++ b/x11-misc/emprint/emprint-9999.ebuild
@@ -1,8 +1,7 @@
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-# $Header: $
 
-EAPI="5"
+EAPI="6"
 EFL_USE_GIT="yes"
 EFL_GIT_REPO_CATEGORY="apps"
 inherit efl
@@ -16,5 +15,4 @@ RDEPEND="x11-libs/libX11
 	|| ( >=dev-libs/efl-9999[X] >=dev-libs/efl-9999[xcb] )
 "
 
-DEPEND="${RDEPEND}
-	x11-proto/xproto"
+DEPEND="${RDEPEND}"

--- a/x11-misc/emprint/metadata.xml
+++ b/x11-misc/emprint/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer>
+<maintainer type="project">
  <email>enlightenment@gentoo.org</email>
 </maintainer>
 </pkgmetadata>


### PR DESCRIPTION
* x11-proto/* no longer available in tree
* bump to EAPI 6
* fix header

Signed-off-by: Bernd Waibel <waebbl@gmail.com>
Package-Manager: Portage-2.3.51, Repoman-2.3.11

compiles on amd64 with these changes.